### PR TITLE
pin npx dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "types": "./dist/index.d.ts",
   "module": "./dist/s2js.esm.js",
   "scripts": {
-    "build": "npx tsdx build --entry index.ts",
-    "docs": "npx typedoc",
+    "build": "npx --yes tsdx@^0 build --entry index.ts",
+    "docs": "npx --yes typedoc",
     "test": "node --import tsx --test [^_]**/[^_]*_test.ts",
     "coverage": "npx c8 npm test",
     "lint": "npx prettier --check .",


### PR DESCRIPTION
This PR fixes the build by pinning the `tsdx` dependency after it jumped from `0.14.1` -> `2.0.0`.

At some point we might migrate but for now a pin with suffice.
https://tsdx.io/docs/migration